### PR TITLE
Rocm Backend: Fix regex for detecting version in Linux

### DIFF
--- a/StableDiffusion.NET/Backends/RocmBackend.cs
+++ b/StableDiffusion.NET/Backends/RocmBackend.cs
@@ -82,7 +82,7 @@ public partial class RocmBackend : IBackend
     [GeneratedRegex(@".*?\\(?<version>\d+.\d*)\\")]
     private static partial Regex GetWindowsVersionRegex();
 
-    [GeneratedRegex(@"HIP_PATH\s*:\s*[\w\/]+-(?<version>[\d.]+)$")]
+    [GeneratedRegex(@"HIP version\s*:\s*(?<version>[\d.]+(?:-\w+)?)")]
     private static partial Regex GetLinuxVersionRegex();
 
     #endregion


### PR DESCRIPTION
Hi, i'm trying out your library on my machine, but i can't use the ROCm backend on Linux
i'm using ArchLinux and rocm 6.0.2 (the version currently included in official arch repos) 

The output from hipconfig is something like this:
```
HIP version  : 6.0.32831-

== hipconfig
HIP_PATH     : /opt/rocm
ROCM_PATH    : /opt/rocm
HIP_COMPILER : clang
HIP_PLATFORM : amd
HIP_RUNTIME  : rocclr
.......
```
...and so on.

As you can see HIP_PATH points to /opt/rocm, and it's not possible to find out rocm's version from there. but we can use the "HIP version" string just on top.

Also, the $ at the end makes the regex never match if there are other characters after the matched string, wich is not what we want.

I made a new regex wich takes the version from "HIP version"


also.... i'm not sure that checking just the major version is enough, but we can talk about that in another thread