### PR TITLE
Allow manually loading SD library

### DIFF
--- a/StableDiffusion.NET/Native/Native.Load.cs
+++ b/StableDiffusion.NET/Native/Native.Load.cs
@@ -26,6 +26,18 @@ internal static partial class Native
 
     #region Methods
 
+    internal static bool LoadNativeLibrary(string libraryPath)
+    {
+        if (_loadedLibraryHandle != nint.Zero) return true;
+        if (NativeLibrary.TryLoad(libraryPath, out nint handle))
+        {
+            _loadedLibraryHandle = handle;
+            return true;
+        }
+
+        return false;
+    }
+
     private static nint ResolveDllImport(string libraryname, Assembly assembly, DllImportSearchPath? searchpath)
     {
         if (libraryname != LIB_NAME) return nint.Zero;

--- a/StableDiffusion.NET/StableDiffusionModel.cs
+++ b/StableDiffusion.NET/StableDiffusionModel.cs
@@ -91,6 +91,15 @@ public sealed unsafe class StableDiffusionModel : IDisposable
         }
     }
 
+    /// <summary>
+    /// Manually load the native stable diffusion library.
+    /// Once set, it will continue to be used for all instances.
+    /// </summary>
+    /// <param name="libraryPath">Path to the stable diffusion library.</param>
+    /// <returns>Bool if the library loaded.</returns>
+    public static bool LoadNativeLibrary(string libraryPath)
+        => Native.LoadNativeLibrary(libraryPath);
+
     public IImage<ColorRGB> TextToImage(string prompt, StableDiffusionParameter parameter)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);


### PR DESCRIPTION
First, thank you for binding this! It saved me time setting it up myself ;).

For loading the `stable-diffusion` library, you have a nifty DllImport hijack to redirect it to search for the right library to load. That's great if you're using your libraries, but I built `libstable-diffusion` for Mac Catalyst. That will throw an exception since it doesn't count in .NET as running on MacOS (Since it's kinda iOS, kinda MacOS, it's a thing) and your code only checks if it's Windows, Mac, or Linux. Likewise, if you build stable-diffusion.cpp for iOS or Android, while your binding should work, it will blow up because of the DllImport code.

If you allow someone to manually pick the library to load, that would let a "power user" like me deal with the native assemblies myself. My PR should enable that, while keeping your existing system in place for others.

